### PR TITLE
Use Blob instead of Data URI to support large file downloads

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,9 +87,10 @@ export default class CsvDownload extends Component {
     }
 
     const a = document.createElement('a');
+    const blob = new Blob([`${bomCode}${this.state.csv}`], { type: 'text/csv;charset=utf-8' });
     a.textContent = 'download';
     a.download = filename;
-    a.href = `data:text/csv;charset=utf-8,${bomCode}${encodeURIComponent(this.state.csv)}`;
+    a.href = URL.createObjectURL(blob)
     a.click();
   }
 


### PR DESCRIPTION
Depending on the browser, Data URIs can have a max length,
([See Length limitations][1]). To get around this we create a Blob with the
data, and then [create a link to that blob][2], which will look something like:
`blob:d3958f5c-0777-0845-9dcf-2cb28783acaf`, which is MUCH shorter than the
respective Data URI.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs#Common_problems
[2]: https://developer.mozilla.org/en-US/docs/Web/API/Blob#Example_for_creating_a_URL_to_a_typed_array_using_a_blob