### PR TITLE
Add disabled option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You can also use the columns definition to set the columns display order
 | wrapColumnChar	| string            	| ''      	|   false  	| Character to wrap every data and header value with.                               	|
 | bom           	| boolean           	| true    	|   false  	| Activate or deactivate bom mode                                                   	|
 | newLineAtEnd  	| boolean           	| false   	|   false  	| Insert new line at end of file.                                                   	|
+| disabled  	    | boolean           	| false   	|   false  	| If `true` the download process is blocked.                                        	|
 
 All other props are passed to button or wrapping component.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ export interface ICsvDownloadProps extends ICsvProps, Omit<React.HTMLAttributes<
   prefix?: PrefixSuffix
   suffix?: PrefixSuffix
   text?: string
+  disabled?: boolean
 }
 
 export default class CsvDownload extends React.Component<ICsvDownloadProps> {
@@ -50,19 +51,24 @@ export default class CsvDownload extends React.Component<ICsvDownloadProps> {
       children, text,
       filename, suffix, prefix, bom,
       columns, datas, separator, noHeader, wrapColumnChar, newLineAtEnd, chunkSize,
+      disabled,
       ...props
     } = this.props
 
+    let onClick = this.handleClick
+    if (disabled)
+      onClick = () => Promise.resolve()
+
     if (typeof children === 'undefined') {
       return (
-        <button type="button" {...props} onClick={this.handleClick}>
+        <button type="button" {...props} onClick={onClick} disabled={disabled}>
           {text ? text : 'Download'}
         </button>
       )
     }
 
     return (
-      <div role="button" tabIndex={0} {...props} onClick={this.handleClick} onKeyPress={this.handleClick}>
+      <div role="button" tabIndex={0} {...props} onClick={onClick} onKeyPress={onClick}>
         {children}
       </div>
     )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,11 @@ export interface ICsvDownloadProps extends ICsvProps, Omit<React.HTMLAttributes<
 
 export default class CsvDownload extends React.Component<ICsvDownloadProps> {
   public handleClick = async () => {
-    const { suffix, prefix, bom, extension } = this.props
+    const { suffix, prefix, bom, extension, disabled } = this.props
+
+    if (disabled)
+      return
+
     let { filename } = this.props
     const csv = await toCsv(this.props)
 
@@ -55,20 +59,16 @@ export default class CsvDownload extends React.Component<ICsvDownloadProps> {
       ...props
     } = this.props
 
-    let onClick = this.handleClick
-    if (disabled)
-      onClick = () => Promise.resolve()
-
     if (typeof children === 'undefined') {
       return (
-        <button type="button" {...props} onClick={onClick} disabled={disabled}>
+        <button type="button" {...props} onClick={this.handleClick} disabled={disabled}>
           {text ? text : 'Download'}
         </button>
       )
     }
 
     return (
-      <div role="button" tabIndex={0} {...props} onClick={onClick} onKeyPress={onClick}>
+      <div role="button" tabIndex={0} {...props} onClick={this.handleClick} onKeyPress={this.handleClick}>
         {children}
       </div>
     )


### PR DESCRIPTION
So this is really handy once we have custom children elements, we can control disabled state here but still `onClick` actions triggers, that's not as expected probably

Also this will add the same `disabled` to default `button` when no custom children selected

I though about trying to get this `disabled` info directly from children but it will lead to some bug-prone code I believe.

I haven't had a chance to test it, if you can, please do :)