### PR TITLE
adds support for sep meta instruction  

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can also use the columns definition to set the columns display order
 | bom            | boolean                      | true    | false    | Activate or deactivate bom mode                                                     |
 | newLineAtEnd   | boolean                      | false   | false    | Insert new line at end of file.                                                     |
 | disabled       | boolean                      | false   | false    | If `true` the download process is blocked.                                          |
-| meta           | boolean                      | false   | false    | If `true` the downloaded file will contain meta instrution sep to help microsoft excel and open office ti recognize the sepator character.                                          |
+| meta           | boolean                      | false   | false    | If `true` the downloaded file will contain meta instrution sep to help microsoft excel and open office to recognize the sepator character.                                          |
 
 All other props are passed to button or wrapping component.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You can also use the columns definition to set the columns display order
 | bom            | boolean                      | true    | false    | Activate or deactivate bom mode                                                     |
 | newLineAtEnd   | boolean                      | false   | false    | Insert new line at end of file.                                                     |
 | disabled       | boolean                      | false   | false    | If `true` the download process is blocked.                                          |
+| meta           | boolean                      | false   | false    | If `true` the downloaded file will contain meta instrution sep to help microsoft excel and open office ti recognize the sepator character.                                          |
 
 All other props are passed to button or wrapping component.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,11 +17,12 @@ export interface ICsvDownloadProps
   suffix?: PrefixSuffix
   text?: string
   disabled?: boolean
+  meta?: boolean
 }
 
 export default class CsvDownload extends React.Component<ICsvDownloadProps> {
   public handleClick = async () => {
-    const { suffix, prefix, bom, extension, disabled } = this.props
+    const { suffix, prefix, bom, extension, disabled, meta, separator } = this.props
 
     if (disabled) {
       return
@@ -31,6 +32,7 @@ export default class CsvDownload extends React.Component<ICsvDownloadProps> {
     const csv = await toCsv(this.props)
 
     const bomCode = bom !== false ? '\ufeff' : ''
+    const metaContent = meta ? `sep=${separator}\r\n` : ''
 
     const resolvedExtension = extension || '.csv'
     if (filename.indexOf(resolvedExtension) === -1) {
@@ -51,7 +53,7 @@ export default class CsvDownload extends React.Component<ICsvDownloadProps> {
           : `${new Date().getTime()}_${filename}`
     }
 
-    const blob = new Blob([`${bomCode}${csv}`], { type: 'text/csv;charset=utf-8' })
+    const blob = new Blob([`${bomCode}${metaContent}${csv}`], { type: 'text/csv;charset=utf-8' })
     FileSaver.saveAs(blob, filename)
   }
 


### PR DESCRIPTION
hey man, I want to push one little more change to your code. 

in my scenario it is extremelly important to add the meta "sep=," to instruct microsof excel and open office auto recognize the columns separator.

I hope it can be included on your code. :)