### PR TITLE
Allowing number type

### DIFF
--- a/src/lib/csv.spec.ts
+++ b/src/lib/csv.spec.ts
@@ -322,4 +322,16 @@ describe('CSV Creator', () => {
       expect(result).to.equal(`k1,k2${newLine}v1,v2${newLine}v3,v4${newLine}v5,v6`)
     })
   })
+
+  describe('Numbers', () => {
+    it('should be ok', async () => {
+      const people = [
+        { name: 'Alice', age: 25 },
+        { name: 'Bob', age: 27 },
+        { name: 'Charlie', age: 40 },
+      ]
+      const result = await csv({ datas: people })
+      expect(result).to.equal(`name,age${newLine}Alice,25${newLine}Bob,27${newLine}Charlie,40`)
+    })
+  })
 })

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -5,7 +5,7 @@ export interface IColumn {
 
 export type ColumnsDefinition = (string | IColumn)[]
 export type Columns = ColumnsDefinition | undefined | false
-export type Datas = (string[] | { [key: string]: string | null | undefined })[]
+export type Datas = (string[] | { [key: string]: string | number | null | undefined })[]
 
 interface Header {
   order: string[]


### PR DESCRIPTION
Partically fixes #372 (for `number` type only)

Problem:
```
const people = [
  { name: 'Alice', age: 25 },
  { name: 'Bob', age: 27 },
  { name: 'Charlie', age: 40 },
];
<CsvDownloader  datas={people} />  <--- ts error: age: number is not allowed
```